### PR TITLE
feat({hw/emu}): Add asynchronous kernel option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,7 @@ dependencies = [
  "criterion",
  "elf",
  "rstest",
+ "thiserror",
  "tracing",
  "tracing-subscriber",
 ]

--- a/crates/emu/Cargo.toml
+++ b/crates/emu/Cargo.toml
@@ -17,6 +17,7 @@ workspace = true
 brisc-hw.workspace = true
 
 # External
+thiserror.workspace = true
 elf = { version = "0.8.0", default-features = false }
 
 # `test-utils` feature

--- a/crates/emu/Cargo.toml
+++ b/crates/emu/Cargo.toml
@@ -33,6 +33,7 @@ const-hex = { version = "1.15.0", features = ["hex"] }
 
 [features]
 default = [ "64-bit", "a", "c", "m" ]
+async-kernel = [ "brisc-hw/async-kernel" ]
 test-utils = [ "dep:rstest", "dep:tracing", "dep:tracing-subscriber" ]
 
 # Architecture features

--- a/crates/emu/Cargo.toml
+++ b/crates/emu/Cargo.toml
@@ -34,7 +34,6 @@ const-hex = { version = "1.15.0", features = ["hex"] }
 
 [features]
 default = [ "64-bit", "a", "c", "m" ]
-async-kernel = [ "brisc-hw/async-kernel" ]
 test-utils = [ "dep:rstest", "dep:tracing", "dep:tracing-subscriber" ]
 
 # Architecture features

--- a/crates/emu/README.md
+++ b/crates/emu/README.md
@@ -59,12 +59,15 @@ const HELLO_WORLD_ELF: &str = "7f454c460201010000000000000000000200f30001000000e
 struct ExampleKernel;
 
 impl Kernel for ExampleKernel {
+    type Error = ();
+
     fn syscall<M: Memory>(
         &mut self,
         sysno: XWord,
         mem: &mut M,
         p_reg: &mut PipelineRegister,
-    ) -> PipelineResult<XWord> {
+        _context: &mut ()
+    ) -> Result<XWord, Self::Error> {
         match sysno {
             0x5D => {
                 let exit_code = p_reg.registers[REG_A0 as usize];
@@ -95,14 +98,16 @@ impl Kernel for ExampleKernel {
 #[derive(Default)]
 struct ExampleEmuConfig;
 
-impl EmuConfig for ExampleEmuConfig {
+impl EmuConfig<'_> for ExampleEmuConfig {
     type Memory = SimpleMemory;
     type Kernel = ExampleKernel;
+    type Context = ();
 }
 
 let elf = const_hex::decode(HELLO_WORLD_ELF).unwrap();
 let mut emu = StEmu::<ExampleEmuConfig>::builder()
     .with_kernel(ExampleKernel)
+    .with_ctx(())
     .with_elf(&elf)
     .unwrap()
     .build();

--- a/crates/emu/src/cfg.rs
+++ b/crates/emu/src/cfg.rs
@@ -3,13 +3,13 @@
 use brisc_hw::{kernel::Kernel, memory::Memory};
 
 /// The [`EmuConfig`] trait defines the type configuration for the emulator.
-pub trait EmuConfig {
+pub trait EmuConfig<'ctx> {
     /// The [Memory] type used by the emulator.
     type Memory: Memory;
 
     /// The kernel used by the emulator.
-    type Kernel<'a>: Kernel<Self::State<'a>>;
+    type Kernel: Kernel<Self::Context> + 'ctx;
 
     /// The external state passed to the kernel.
-    type State<'a>;
+    type Context: 'ctx;
 }

--- a/crates/emu/src/cfg.rs
+++ b/crates/emu/src/cfg.rs
@@ -8,5 +8,8 @@ pub trait EmuConfig {
     type Memory: Memory;
 
     /// The kernel used by the emulator.
-    type Kernel: Kernel;
+    type Kernel<'a>: Kernel<Self::State<'a>>;
+
+    /// The external state passed to the kernel.
+    type State<'a>;
 }

--- a/crates/emu/src/cfg.rs
+++ b/crates/emu/src/cfg.rs
@@ -1,6 +1,6 @@
 //! Emulator type configuration trait
 
-use brisc_hw::{kernel::Kernel, memory::Memory};
+use brisc_hw::memory::Memory;
 
 /// The [`EmuConfig`] trait defines the type configuration for the emulator.
 pub trait EmuConfig<'ctx> {
@@ -8,7 +8,7 @@ pub trait EmuConfig<'ctx> {
     type Memory: Memory;
 
     /// The kernel used by the emulator.
-    type Kernel: Kernel<Self::Context> + 'ctx;
+    type Kernel;
 
     /// The external state passed to the kernel.
     type Context: 'ctx;

--- a/crates/emu/src/st/builder.rs
+++ b/crates/emu/src/st/builder.rs
@@ -9,21 +9,21 @@ use brisc_hw::{pipeline::PipelineRegister, XWord};
 #[derive(Debug)]
 pub struct StEmuBuilder<'ctx, Config>
 where
-    Config: EmuConfig,
+    Config: EmuConfig<'ctx>,
 {
     /// The starting program counter.
     pub pc: XWord,
     /// The initial memory for the emulator.
     pub memory: Option<Config::Memory>,
     /// The system call interface for the emulator.
-    pub kernel: Option<Config::Kernel<'ctx>>,
+    pub kernel: Option<Config::Kernel>,
     /// The emulator's state.
-    pub state: Option<Config::State<'ctx>>,
+    pub state: Option<Config::Context>,
 }
 
 impl<'ctx, Config> Default for StEmuBuilder<'ctx, Config>
 where
-    Config: EmuConfig,
+    Config: EmuConfig<'ctx>,
 {
     fn default() -> Self {
         Self { pc: 0, memory: None, kernel: None, state: None }
@@ -32,7 +32,7 @@ where
 
 impl<'ctx, Config> StEmuBuilder<'ctx, Config>
 where
-    Config: EmuConfig,
+    Config: EmuConfig<'ctx>,
     Config::Memory: Default,
 {
     /// Loads an elf file into the emulator builder, initializing the program counter and memory.
@@ -46,7 +46,7 @@ where
 
 impl<'ctx, Config> StEmuBuilder<'ctx, Config>
 where
-    Config: EmuConfig,
+    Config: EmuConfig<'ctx>,
 {
     /// Assigns the entry point of the program.
     pub const fn with_pc(mut self, pc: XWord) -> Self {
@@ -61,13 +61,13 @@ where
     }
 
     /// Assigns the kernel to the emulator.
-    pub fn with_kernel(mut self, kernel: Config::Kernel<'ctx>) -> Self {
+    pub fn with_kernel(mut self, kernel: Config::Kernel) -> Self {
         self.kernel = Some(kernel);
         self
     }
 
     /// Assigns the state to the emulator.
-    pub fn with_state(mut self, state: Config::State<'ctx>) -> Self {
+    pub fn with_ctx(mut self, state: Config::Context) -> Self {
         self.state = Some(state);
         self
     }
@@ -82,7 +82,7 @@ where
             register: PipelineRegister::new(self.pc),
             memory: self.memory.expect("Memory not instantiated"),
             kernel: self.kernel.expect("Kernel not instantiated"),
-            state: self.state.expect("State not instantiated"),
+            ctx: self.state.expect("State not instantiated"),
         }
     }
 }

--- a/crates/emu/src/st/builder.rs
+++ b/crates/emu/src/st/builder.rs
@@ -17,8 +17,8 @@ where
     pub memory: Option<Config::Memory>,
     /// The system call interface for the emulator.
     pub kernel: Option<Config::Kernel>,
-    /// The emulator's state.
-    pub state: Option<Config::Context>,
+    /// The emulator's external context.
+    pub ctx: Option<Config::Context>,
 }
 
 impl<'ctx, Config> Default for StEmuBuilder<'ctx, Config>
@@ -26,7 +26,7 @@ where
     Config: EmuConfig<'ctx>,
 {
     fn default() -> Self {
-        Self { pc: 0, memory: None, kernel: None, state: None }
+        Self { pc: 0, memory: None, kernel: None, ctx: None }
     }
 }
 
@@ -66,9 +66,9 @@ where
         self
     }
 
-    /// Assigns the state to the emulator.
-    pub fn with_ctx(mut self, state: Config::Context) -> Self {
-        self.state = Some(state);
+    /// Assigns the context to the emulator.
+    pub fn with_ctx(mut self, ctx: Config::Context) -> Self {
+        self.ctx = Some(ctx);
         self
     }
 
@@ -82,7 +82,7 @@ where
             register: PipelineRegister::new(self.pc),
             memory: self.memory.expect("Memory not instantiated"),
             kernel: self.kernel.expect("Kernel not instantiated"),
-            ctx: self.state.expect("State not instantiated"),
+            ctx: self.ctx.expect("Context not instantiated"),
         }
     }
 }

--- a/crates/emu/src/st/mod.rs
+++ b/crates/emu/src/st/mod.rs
@@ -16,21 +16,21 @@ pub use builder::StEmuBuilder;
 #[derive(Debug, Default)]
 pub struct StEmu<'ctx, Config>
 where
-    Config: EmuConfig,
+    Config: EmuConfig<'ctx>,
 {
     /// The pipeline register.
     pub register: PipelineRegister,
     /// The device memory.
     pub memory: Config::Memory,
     /// The system call interface.
-    pub kernel: Config::Kernel<'ctx>,
+    pub kernel: Config::Kernel,
     /// The emulator's context.
-    pub state: Config::State<'ctx>,
+    pub ctx: Config::Context,
 }
 
 impl<'ctx, Config> StEmu<'ctx, Config>
 where
-    Config: EmuConfig,
+    Config: EmuConfig<'ctx>,
 {
     /// Creates a new [`StEmuBuilder`].
     pub fn builder() -> StEmuBuilder<'ctx, Config> {
@@ -64,7 +64,7 @@ where
         match cycle_res {
             Ok(()) => {}
             Err(PipelineError::SyscallException(syscall_no)) => {
-                self.kernel.syscall(syscall_no, &mut self.memory, r, &mut self.state)?;
+                self.kernel.syscall(syscall_no, &mut self.memory, r, &mut self.ctx)?;
 
                 // Exit emulation if the syscall terminated the program.
                 if r.exit {
@@ -105,7 +105,7 @@ where
         match cycle_res {
             Ok(()) => {}
             Err(PipelineError::SyscallException(syscall_no)) => {
-                self.kernel.syscall(syscall_no, &mut self.memory, r, &mut self.state).await?;
+                self.kernel.syscall(syscall_no, &mut self.memory, r, &mut self.ctx).await?;
 
                 // Exit emulation if the syscall terminated the program.
                 if r.exit {

--- a/crates/emu/src/st/mod.rs
+++ b/crates/emu/src/st/mod.rs
@@ -3,7 +3,7 @@
 use crate::cfg::EmuConfig;
 use brisc_hw::{
     errors::PipelineError,
-    kernel::Kernel,
+    kernel::{AsyncKernel, Kernel},
     pipeline::{
         decode_instruction, execute, instruction_fetch, mem_access, writeback, PipelineRegister,
     },
@@ -15,21 +15,18 @@ pub use builder::StEmuBuilder;
 
 /// An error that can occur during emulation.
 #[derive(Error, Debug)]
-pub enum EmulationError<S, K: Kernel<S>> {
+pub enum EmulationError<E> {
     /// An error that occurred in the pipeline.
     #[error(transparent)]
     Pipeline(#[from] PipelineError),
 
     /// An error that occurred in the kernel.
     #[error(transparent)]
-    Kernel(K::Error),
+    Kernel(E),
 }
 
 /// A [`Result`] type aslias for emulation results.
-pub type EmulationResult<'a, T, Config> = Result<
-    T,
-    EmulationError<<Config as EmuConfig<'a>>::Context, <Config as EmuConfig<'a>>::Kernel>,
->;
+pub type EmulationResult<T, KernelError> = Result<T, EmulationError<KernelError>>;
 
 /// Single-cycle RISC-V processor emulator.
 #[derive(Debug, Default)]
@@ -56,9 +53,21 @@ where
         StEmuBuilder::default()
     }
 
+    /// Destroys the emulator and returns the context.
+    pub fn take_ctx(self) -> Config::Context {
+        self.ctx
+    }
+}
+
+impl<'ctx, Config> StEmu<'ctx, Config>
+where
+    Config: EmuConfig<'ctx>,
+    Config::Kernel: Kernel<Config::Context> + 'ctx,
+{
     /// Executes the program until it exits, returning the final [PipelineRegister].
-    #[cfg(not(feature = "async-kernel"))]
-    pub fn run(&mut self) -> EmulationResult<'ctx, PipelineRegister, Config> {
+    pub fn run(
+        &mut self,
+    ) -> EmulationResult<PipelineRegister, <Config::Kernel as Kernel<Config::Context>>::Error> {
         while !self.register.exit {
             self.cycle()?;
         }
@@ -68,8 +77,9 @@ where
 
     /// Execute a single cycle of the processor in full.
     #[inline(always)]
-    #[cfg(not(feature = "async-kernel"))]
-    pub fn cycle(&mut self) -> EmulationResult<'ctx, (), Config> {
+    pub fn cycle(
+        &mut self,
+    ) -> EmulationResult<(), <Config::Kernel as Kernel<Config::Context>>::Error> {
         let r = &mut self.register;
 
         // Execute all pipeline stages sequentially.
@@ -98,12 +108,20 @@ where
         r.advance();
         Ok(())
     }
+}
 
+impl<'ctx, Config> StEmu<'ctx, Config>
+where
+    Config: EmuConfig<'ctx>,
+    Config::Kernel: AsyncKernel<Config::Context> + 'ctx,
+{
     /// Executes the program until it exits, returning the final [PipelineRegister].
-    #[cfg(feature = "async-kernel")]
-    pub async fn run(&mut self) -> EmulationResult<'ctx, PipelineRegister, Config> {
+    pub async fn run_async(
+        &mut self,
+    ) -> EmulationResult<PipelineRegister, <Config::Kernel as AsyncKernel<Config::Context>>::Error>
+    {
         while !self.register.exit {
-            self.cycle().await?;
+            self.cycle_async().await?;
         }
 
         Ok(self.register)
@@ -111,8 +129,9 @@ where
 
     /// Execute a single cycle of the processor in full.
     #[inline(always)]
-    #[cfg(feature = "async-kernel")]
-    pub async fn cycle(&mut self) -> EmulationResult<'ctx, (), Config> {
+    pub async fn cycle_async(
+        &mut self,
+    ) -> EmulationResult<(), <Config::Kernel as AsyncKernel<Config::Context>>::Error> {
         let r = &mut self.register;
 
         // Execute all pipeline stages sequentially.
@@ -141,11 +160,6 @@ where
 
         r.advance();
         Ok(())
-    }
-
-    /// Destroys the emulator and returns the context.
-    pub fn take_ctx(self) -> Config::Context {
-        self.ctx
     }
 }
 

--- a/crates/emu/src/test_utils.rs
+++ b/crates/emu/src/test_utils.rs
@@ -2,7 +2,6 @@
 
 use crate::{cfg::EmuConfig, st::StEmu};
 use brisc_hw::{
-    errors::PipelineResult,
     kernel::Kernel,
     memory::{Memory, SimpleMemory},
     pipeline::PipelineRegister,
@@ -87,17 +86,19 @@ impl EmuConfig<'_> for TestStEmuConfig {
     type Context = ();
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 struct RiscvTestKernel;
 
 impl Kernel<()> for RiscvTestKernel {
+    type Error = ();
+
     fn syscall<M: Memory>(
         &mut self,
         sysno: XWord,
         mem: &mut M,
         p_reg: &mut PipelineRegister,
         _: &mut (),
-    ) -> PipelineResult<XWord> {
+    ) -> Result<XWord, Self::Error> {
         match sysno {
             0x5D => {
                 let exit_code = p_reg.registers[REG_A0 as usize];

--- a/crates/emu/src/test_utils.rs
+++ b/crates/emu/src/test_utils.rs
@@ -48,6 +48,7 @@ pub fn run_riscv_test(test_path: &PathBuf) -> f64 {
     let elf_bytes = fs::read(test_path).unwrap();
     let mut hart = StEmu::<TestStEmuConfig>::builder()
         .with_kernel(RiscvTestKernel)
+        .with_state(())
         .with_elf(&elf_bytes)
         .unwrap()
         .build();
@@ -81,18 +82,21 @@ struct TestStEmuConfig;
 impl EmuConfig for TestStEmuConfig {
     type Memory = SimpleMemory;
 
-    type Kernel = RiscvTestKernel;
+    type Kernel<'ctx> = RiscvTestKernel;
+
+    type State<'ctx> = ();
 }
 
 #[derive(Default)]
 struct RiscvTestKernel;
 
-impl Kernel for RiscvTestKernel {
+impl Kernel<()> for RiscvTestKernel {
     fn syscall<M: Memory>(
         &mut self,
         sysno: XWord,
         mem: &mut M,
         p_reg: &mut PipelineRegister,
+        _: &mut (),
     ) -> PipelineResult<XWord> {
         match sysno {
             0x5D => {

--- a/crates/emu/src/test_utils.rs
+++ b/crates/emu/src/test_utils.rs
@@ -48,7 +48,7 @@ pub fn run_riscv_test(test_path: &PathBuf) -> f64 {
     let elf_bytes = fs::read(test_path).unwrap();
     let mut hart = StEmu::<TestStEmuConfig>::builder()
         .with_kernel(RiscvTestKernel)
-        .with_state(())
+        .with_ctx(())
         .with_elf(&elf_bytes)
         .unwrap()
         .build();
@@ -79,12 +79,12 @@ pub fn run_riscv_test(test_path: &PathBuf) -> f64 {
 #[derive(Default)]
 struct TestStEmuConfig;
 
-impl EmuConfig for TestStEmuConfig {
+impl EmuConfig<'_> for TestStEmuConfig {
     type Memory = SimpleMemory;
 
-    type Kernel<'ctx> = RiscvTestKernel;
+    type Kernel = RiscvTestKernel;
 
-    type State<'ctx> = ();
+    type Context = ();
 }
 
 #[derive(Default)]

--- a/crates/emu/src/test_utils.rs
+++ b/crates/emu/src/test_utils.rs
@@ -101,14 +101,14 @@ impl Kernel<()> for RiscvTestKernel {
     ) -> Result<XWord, Self::Error> {
         match sysno {
             0x5D => {
-                let exit_code = p_reg.registers[REG_A0 as usize];
+                let exit_code = p_reg.registers[REG_A0];
                 p_reg.exit_code = exit_code;
                 p_reg.exit = true;
             }
             0x40 => {
-                let fd = p_reg.registers[REG_A0 as usize];
-                let ptr = p_reg.registers[REG_A1 as usize];
-                let len = p_reg.registers[REG_A2 as usize];
+                let fd = p_reg.registers[REG_A0];
+                let ptr = p_reg.registers[REG_A1];
+                let len = p_reg.registers[REG_A2];
 
                 let raw_msg = mem.read_memory_range(ptr, len).unwrap();
                 let msg = String::from_utf8_lossy(&raw_msg);

--- a/crates/hw/Cargo.toml
+++ b/crates/hw/Cargo.toml
@@ -26,6 +26,7 @@ rstest.workspace = true
 
 [features]
 default = [ "64-bit", "a", "c", "m" ]
+async-kernel = []
 
 # Architecture features
 64-bit = [ "brisc-isa/64-bit" ]

--- a/crates/hw/Cargo.toml
+++ b/crates/hw/Cargo.toml
@@ -26,7 +26,6 @@ rstest.workspace = true
 
 [features]
 default = [ "64-bit", "a", "c", "m" ]
-async-kernel = []
 
 # Architecture features
 64-bit = [ "brisc-isa/64-bit" ]

--- a/crates/hw/src/kernel.rs
+++ b/crates/hw/src/kernel.rs
@@ -4,22 +4,47 @@ use crate::{errors::PipelineResult, memory::Memory, pipeline::PipelineRegister};
 use brisc_isa::XWord;
 
 /// The [`Kernel`] trait defines the interface for performing system calls.
-pub trait Kernel {
+pub trait Kernel<S> {
     /// Perform a system call with the given arguments.
+    #[cfg(not(feature = "async-kernel"))]
     fn syscall<M: Memory>(
         &mut self,
         syscall_no: XWord,
         memory: &mut M,
         p_reg: &mut PipelineRegister,
+        state: &mut S,
     ) -> PipelineResult<XWord>;
+
+    /// Perform a system call with the given arguments.
+    #[cfg(feature = "async-kernel")]
+    fn syscall<M: Memory>(
+        &mut self,
+        syscall_no: XWord,
+        memory: &mut M,
+        p_reg: &mut PipelineRegister,
+        state: &mut S,
+    ) -> impl core::future::Future<Output = PipelineResult<XWord>>;
 }
 
-impl Kernel for () {
+impl<S> Kernel<S> for () {
+    #[cfg(not(feature = "async-kernel"))]
     fn syscall<M: Memory>(
         &mut self,
         _: XWord,
         _: &mut M,
         _: &mut PipelineRegister,
+        _: &mut S,
+    ) -> PipelineResult<XWord> {
+        unimplemented!()
+    }
+
+    #[cfg(feature = "async-kernel")]
+    async fn syscall<M: Memory>(
+        &mut self,
+        _: XWord,
+        _: &mut M,
+        _: &mut PipelineRegister,
+        _: &mut S,
     ) -> PipelineResult<XWord> {
         unimplemented!()
     }

--- a/crates/hw/src/kernel.rs
+++ b/crates/hw/src/kernel.rs
@@ -4,35 +4,23 @@ use crate::{memory::Memory, pipeline::PipelineRegister};
 use brisc_isa::XWord;
 
 /// The [`Kernel`] trait defines the interface for performing system calls.
-pub trait Kernel<S> {
+pub trait Kernel<S = ()> {
     /// The error type returned by the kernel.
     type Error;
 
     /// Perform a system call with the given arguments.
-    #[cfg(not(feature = "async-kernel"))]
     fn syscall<M: Memory>(
         &mut self,
         syscall_no: XWord,
         memory: &mut M,
         p_reg: &mut PipelineRegister,
-        state: &mut S,
+        ctx: &mut S,
     ) -> Result<XWord, Self::Error>;
-
-    /// Perform a system call with the given arguments.
-    #[cfg(feature = "async-kernel")]
-    fn syscall<M: Memory>(
-        &mut self,
-        syscall_no: XWord,
-        memory: &mut M,
-        p_reg: &mut PipelineRegister,
-        state: &mut S,
-    ) -> impl core::future::Future<Output = Result<XWord, Self::Error>>;
 }
 
 impl<S> Kernel<S> for () {
     type Error = ();
 
-    #[cfg(not(feature = "async-kernel"))]
     fn syscall<M: Memory>(
         &mut self,
         _: XWord,
@@ -42,8 +30,26 @@ impl<S> Kernel<S> for () {
     ) -> Result<XWord, Self::Error> {
         unimplemented!()
     }
+}
 
-    #[cfg(feature = "async-kernel")]
+/// The [`Kernel`] trait defines the interface for performing asynchronous system calls.
+pub trait AsyncKernel<S = ()> {
+    /// The error type returned by the kernel.
+    type Error;
+
+    /// Perform a system call with the given arguments.
+    fn syscall<M: Memory>(
+        &mut self,
+        syscall_no: XWord,
+        memory: &mut M,
+        p_reg: &mut PipelineRegister,
+        ctx: &mut S,
+    ) -> impl core::future::Future<Output = Result<XWord, Self::Error>>;
+}
+
+impl<S> AsyncKernel<S> for () {
+    type Error = ();
+
     async fn syscall<M: Memory>(
         &mut self,
         _: XWord,
@@ -51,6 +57,6 @@ impl<S> Kernel<S> for () {
         _: &mut PipelineRegister,
         _: &mut S,
     ) -> Result<XWord, Self::Error> {
-        unimplemented!()
+        unimplemented!();
     }
 }

--- a/crates/hw/src/memory/errors.rs
+++ b/crates/hw/src/memory/errors.rs
@@ -1,26 +1,19 @@
 //! Memory related errors
 
 use crate::memory::Address;
-use alloc::string::String;
-use core::fmt::{Debug, Display};
+use core::fmt::Debug;
 use thiserror::Error;
 
 /// An error type for memory operations.
 #[derive(Error, Debug, Clone, Eq, PartialEq)]
-pub enum MemoryError<T = String>
-where
-    T: Display + Debug + Clone + Eq + PartialEq,
-{
+pub enum MemoryError {
     /// The page at the given index could not be found.
     #[error("Page not found at page index {0:08x}")]
     PageNotFound(Address),
     /// Unaligned memory access.
     #[error("Unaligned memory access at address {0:08x}")]
     UnalignedAccess(Address),
-    /// Custom memory error.
-    #[error("Memory error: {0}")]
-    Custom(#[from] T),
 }
 
 /// Type alias for a [Result] with [Result::Err] = [MemoryError].
-pub type MemoryResult<T, E = String> = Result<T, MemoryError<E>>;
+pub type MemoryResult<T> = Result<T, MemoryError>;

--- a/crates/hw/src/pipeline/decode.rs
+++ b/crates/hw/src/pipeline/decode.rs
@@ -25,7 +25,7 @@ pub fn decode_instruction(register: &mut PipelineRegister) -> PipelineResult<()>
 
     // Throw an interrupt if the instruction is a system call.
     if instruction.is_system_call() {
-        return Err(PipelineError::SyscallException(register.registers[REG_A7 as usize]));
+        return Err(PipelineError::SyscallException(register.registers[REG_A7]));
     }
 
     Ok(())

--- a/crates/hw/src/pipeline/execute.rs
+++ b/crates/hw/src/pipeline/execute.rs
@@ -31,16 +31,16 @@ pub fn execute(p_reg: &mut PipelineRegister) -> PipelineResult<()> {
         }
         Instruction::RegisterArithmetic(_, funct) => execute_reg_arithmetic(p_reg, funct)?,
         Instruction::Lui(u_type) => u_type.imm,
-        Instruction::Auipc(u_type) => p_reg.pc + u_type.imm,
+        Instruction::Auipc(u_type) => p_reg.pc.wrapping_add(u_type.imm),
         Instruction::Jal(j_type) => {
             let result = p_reg.next_pc;
-            p_reg.next_pc = p_reg.pc + j_type.imm;
+            p_reg.next_pc = p_reg.pc.wrapping_add(j_type.imm);
             result
         }
         Instruction::Jalr(i_type) => {
             let result = p_reg.next_pc;
             let rs1 = p_reg.rs1_value.ok_or(PipelineError::MissingState("rs1_value"))?;
-            p_reg.next_pc = (rs1 + i_type.imm) & !1;
+            p_reg.next_pc = (rs1.wrapping_add(i_type.imm)) & !1;
             result
         }
         Instruction::Fence => {
@@ -87,7 +87,7 @@ fn execute_branch(
 ) -> PipelineResult<XWord> {
     let rs1 = p_reg.rs1_value.ok_or(PipelineError::MissingState("rs1_value"))?;
     let rs2 = p_reg.rs2_value.ok_or(PipelineError::MissingState("rs2_value"))?;
-    let target = p_reg.pc + b_type.imm;
+    let target = p_reg.pc.wrapping_add(b_type.imm);
 
     match funct {
         BranchFunction::Beq => {
@@ -258,7 +258,7 @@ fn execute_imm_arithmetic_word(
     let rs1 = p_reg.rs1_value.ok_or(PipelineError::MissingState("rs1_value"))? as Word;
 
     let result = match funct {
-        ImmediateArithmeticWordFunction::Addiw => (i_type.imm as Word) + rs1,
+        ImmediateArithmeticWordFunction::Addiw => (i_type.imm as Word).wrapping_add(rs1),
         ImmediateArithmeticWordFunction::Slliw => rs1 << (i_type.imm & 0x1F),
         ImmediateArithmeticWordFunction::Srliw => rs1 >> (i_type.imm & 0x1F),
         ImmediateArithmeticWordFunction::Sraiw => ((rs1 as i32) >> (i_type.imm & 0x1F)) as Word,

--- a/crates/isa/src/arch.rs
+++ b/crates/isa/src/arch.rs
@@ -73,97 +73,97 @@ cfg_if! {
 }
 
 /// hardwired zero
-pub const REG_ZERO: XWord = 0;
+pub const REG_ZERO: usize = 0;
 
 /// return address
-pub const REG_RA: XWord = 1;
+pub const REG_RA: usize = 1;
 
 /// stack pointer
-pub const REG_SP: XWord = 2;
+pub const REG_SP: usize = 2;
 
 /// global pointer
-pub const REG_GP: XWord = 3;
+pub const REG_GP: usize = 3;
 
 /// thread pointer
-pub const REG_TP: XWord = 4;
+pub const REG_TP: usize = 4;
 
 /// temporary register 0
-pub const REG_T0: XWord = 5;
+pub const REG_T0: usize = 5;
 
 /// temporary register 1
-pub const REG_T1: XWord = 6;
+pub const REG_T1: usize = 6;
 
 /// temporary register 2
-pub const REG_T2: XWord = 7;
+pub const REG_T2: usize = 7;
 
 /// saved register / frame pointer
-pub const REG_S0_FP: XWord = 8;
+pub const REG_S0_FP: usize = 8;
 
 /// saved register 1
-pub const REG_S1: XWord = 9;
+pub const REG_S1: usize = 9;
 
 /// function argument 0 / return value 0
-pub const REG_A0: XWord = 10;
+pub const REG_A0: usize = 10;
 
 /// function argument 1 / return value 1
-pub const REG_A1: XWord = 11;
+pub const REG_A1: usize = 11;
 
 /// function argument 2
-pub const REG_A2: XWord = 12;
+pub const REG_A2: usize = 12;
 
 /// function argument 3
-pub const REG_A3: XWord = 13;
+pub const REG_A3: usize = 13;
 
 /// function argument 4
-pub const REG_A4: XWord = 14;
+pub const REG_A4: usize = 14;
 
 /// function argument 5
-pub const REG_A5: XWord = 15;
+pub const REG_A5: usize = 15;
 
 /// function argument 6
-pub const REG_A6: XWord = 16;
+pub const REG_A6: usize = 16;
 
 /// function argument 7
-pub const REG_A7: XWord = 17;
+pub const REG_A7: usize = 17;
 
 /// saved register 2
-pub const REG_S2: XWord = 18;
+pub const REG_S2: usize = 18;
 
 /// saved register 3
-pub const REG_S3: XWord = 19;
+pub const REG_S3: usize = 19;
 
 /// saved register 4
-pub const REG_S4: XWord = 20;
+pub const REG_S4: usize = 20;
 
 /// saved register 5
-pub const REG_S5: XWord = 21;
+pub const REG_S5: usize = 21;
 
 /// saved register 6
-pub const REG_S6: XWord = 22;
+pub const REG_S6: usize = 22;
 
 /// saved register 7
-pub const REG_S7: XWord = 23;
+pub const REG_S7: usize = 23;
 
 /// saved register 8
-pub const REG_S8: XWord = 24;
+pub const REG_S8: usize = 24;
 
 /// saved register 9
-pub const REG_S9: XWord = 25;
+pub const REG_S9: usize = 25;
 
 /// saved register 10
-pub const REG_S10: XWord = 26;
+pub const REG_S10: usize = 26;
 
 /// saved register 11
-pub const REG_S11: XWord = 27;
+pub const REG_S11: usize = 27;
 
 /// temporary register 3
-pub const REG_T3: XWord = 28;
+pub const REG_T3: usize = 28;
 
 /// temporary register 4
-pub const REG_T4: XWord = 29;
+pub const REG_T4: usize = 29;
 
 /// temporary register 5
-pub const REG_T5: XWord = 30;
+pub const REG_T5: usize = 30;
 
 /// temporary register 6
-pub const REG_T6: XWord = 31;
+pub const REG_T6: usize = 31;


### PR DESCRIPTION
## Overview

Adds a new option to use an asynchronous `Kernel` in the `StEmu`.

Also a few periphery changes:
- `REG_*` constants are now `usize`, better ergonomics given that they're usually used to index.
- `JAL`, `JALR`, `AUIPC` now use `wrapping_add`.